### PR TITLE
fix signature headers

### DIFF
--- a/signature.js
+++ b/signature.js
@@ -1,4 +1,7 @@
 import crypto from 'crypto'; // Import crypto module
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env' });
 
 const domain = process.env.DOMAIN;
 const account = process.env.ACCOUNT;
@@ -73,7 +76,7 @@ export function getSignatureParams(body, method, url) {
  */
 export function getSignatureHeader(signature, signatureKeys) {
   return [
-    `keyId="https://${domain}/u/${account}"`,
+    `keyId="https://${domain}/u/${account}#main-key"`,
     `algorithm="rsa-sha256"`,
     `headers="${signatureKeys.join(' ')}"`,
     `signature="${signature}"`,


### PR DESCRIPTION
Environment variables were reading as `undefined`, leading to incorrect sender identity in the signature ID. 

The id for the key was also wrong as it was missing the hash id.

Fixes #4 